### PR TITLE
Remove manual rate computation for secondary pricing

### DIFF
--- a/secondary_pricelist/public/js/sales_order_secondary_pricelist.js
+++ b/secondary_pricelist/public/js/sales_order_secondary_pricelist.js
@@ -92,28 +92,20 @@ function check_and_apply_secondary_pricing(frm, cdt, cdn) {
                 company: frm.doc.company  // Pass company for base currency
             },
             callback: function(r) {
-                if (r.message && r.message.rate) {
-                    // Set both rate (Sales Order currency) and base_rate (Company currency)
-                    frappe.model.set_value(cdt, cdn, 'rate', r.message.rate);
-                    frappe.model.set_value(cdt, cdn, 'price_list_rate', r.message.rate);
-                    
-                    // ERPNext will automatically calculate base_rate using conversion_rate
-                    // But we can also set it explicitly to ensure consistency
-                    if (r.message.base_rate) {
-                        frappe.model.set_value(cdt, cdn, 'base_rate', r.message.base_rate);
-                        frappe.model.set_value(cdt, cdn, 'base_price_list_rate', r.message.base_rate);
+                if (r.message && r.message.price_list_rate) {
+                    // Set price_list_rate (Sales Order currency)
+                    frappe.model.set_value(cdt, cdn, 'price_list_rate', r.message.price_list_rate);
+
+                    // Set base_price_list_rate (Company currency) if provided
+                    if (r.message.base_price_list_rate) {
+                        frappe.model.set_value(cdt, cdn, 'base_price_list_rate', r.message.base_price_list_rate);
                     }
-                    
-                    // Show detailed message about secondary pricing with currency flow
-                    let message = __('Price applied from secondary pricelist: {0}', [frm.doc.custom_secondary_pricelist]);
-                    if (r.message.currency_converted) {
-                        message += '<br><small>' + r.message.exchange_info + '</small>';
-                    }
-                    
+
+                    // ERPNext will derive rate and base_rate from price list rates
                     frappe.show_alert({
-                        message: message,
+                        message: __('Price applied from secondary pricelist: {0}', [frm.doc.custom_secondary_pricelist]),
                         indicator: 'blue'
-                    }, 6);  // Show for 6 seconds to read conversion info
+                    }, 6);
                 }
             }
         });


### PR DESCRIPTION
## Summary
- stop setting item.rate and base_rate for secondary pricelist conversions
- return only `price_list_rate` and `base_price_list_rate` from secondary price API
- update Sales Order client script to use price list rates exclusively
- avoid comment insertion on unsaved items to prevent reference errors

## Testing
- `pytest`
- `python -m py_compile secondary_pricelist/overrides/sales_order.py`


------
https://chatgpt.com/codex/tasks/task_b_68a5c4b3fe7883228bb8a5c13020c321