### PR TITLE
Fix project name: use underscore to match Python module name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
-name = "secondary-pricelist"
+name = "secondary_pricelist"
 version = "1.0.0"
 description = "Adds secondary pricelist functionality to Sales Order"
 authors = [


### PR DESCRIPTION
Changed [project] name from "secondary-pricelist" (hyphen) to "secondary_pricelist" (underscore) to match the actual module directory. All official Frappe apps use underscores in project names.

https://claude.ai/code/session_01KACYQg88M8dM38pRVk1nCL